### PR TITLE
add-closeOrderByPayment

### DIFF
--- a/src/Pay/Payment/WechatGateway.php
+++ b/src/Pay/Payment/WechatGateway.php
@@ -141,6 +141,17 @@ class WechatGateway extends AbstractGateway
         return $response;
     }
 
+    public function closeTrade($trade)
+    {
+        $gateway = $this->createGetWay("WechatPay");
+
+        $response = $gateway->close(array(
+            'out_trade_no' => $trade['trade_sn']
+        ))->send();
+
+        return $response;
+    }
+
     public function converterRefundNotify($data)
     {
         $gateway = $this->createGateway('WechatPay');

--- a/src/Pay/Service/Impl/PayServiceImpl.php
+++ b/src/Pay/Service/Impl/PayServiceImpl.php
@@ -136,15 +136,12 @@ class PayServiceImpl extends BaseService implements PayService
             }
 
             $trade = $this->getTradeContext($trade['id'])->closing();
-
             if($this->isCloseByPayment()){
                 $this->closeByPayment($trade);
-            } else {
-                $data = array(
-                    'sn' => $trade['trade_sn'],
-                );
-                $this->notifyClosed($data);
-            }
+            } 
+
+            $data = array('sn' => $trade['trade_sn']);
+            $this->notifyClosed($data);
         }
     }
 
@@ -222,9 +219,17 @@ class PayServiceImpl extends BaseService implements PayService
         return empty($this->biz['payment.final_options']['closed_by_notify']) ? false : $this->biz['payment.final_options']['closed_by_notify'];
     }
 
-    protected function closeByPayment($trade)
+    protected function closeByPayment($data)
     {
-        return $this->getPayment($trade['platform'])->closeTrade($trade);
+        $response = $this->getPayment($data['platform'])->closeTrade($data);
+        if (!$response->isSuccessful()) {
+            $failData = $response->getFailData();
+            $this->getTargetlogService()->log(TargetlogService::INFO, 'trade.close_failed', $data['trade_sn'], "交易号{$data['trade_sn']}关闭失败,{$failData},(order_sn:{$data['order_sn']})", $data);
+        }else{
+            $this->getTargetlogService()->log(TargetlogService::INFO, 'trade.close', $data['trade_sn'], "交易号{$data['trade_sn']}关闭成功。(order_sn:{$data['order_sn']})", $data);
+        }
+
+        return $response;
     }
 
     protected function updateTradeToPaidAndTransferAmount($data)


### PR DESCRIPTION
通知微信关闭订单，会在targetlog中记录成功或者失败原因，getFailData方法在写omnipay-wechatpay项目中。
ps：微信那边规定：至少需要创建订单五分钟以上才可以关闭。